### PR TITLE
Remove setup.cfg

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,5 +1,6 @@
 [flake8]
 ignore = C901, E203, E266, E501, E722, W503, F403, F401, F821
+exclude = .git,__pycache__,docs/source/,old,build,dist,./venv/,example_code.py
 max-line-length = 119
 max-complexity = 18
 select = B,C,E,F,W,T4,B9

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,3 +14,6 @@ exclude = '''
   | dist
 )/
 '''
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,0 @@
-[tool:pytest]
-testpaths = tests/ 
-
-[flake8]
-exclude = .git,__pycache__,docs/source/,old,build,dist,./venv/,example_code.py


### PR DESCRIPTION
Simple PR. Content of setup.cfg was dissolved into two other files and now can be removed