### PR TITLE
Add cache to functions that calls StackOverflow API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,8 @@ tests/__pycache__/
 pycee2.egg-info/
 output.txt
 .tool-versions
+
+# ignore cached answers
+pycee/*cache.bak
+pycee/*cache.dat
+pycee/*cache.dir

--- a/pycee/answers.py
+++ b/pycee/answers.py
@@ -4,10 +4,11 @@
 
 import re
 from keyword import kwlist
-from typing import List
+from typing import List, Tuple
 from difflib import get_close_matches
 
 import requests
+from filecache import filecache, WEEK
 from sumy.nlp.tokenizers import Tokenizer
 from sumy.summarizers.luhn import LuhnSummarizer
 from sumy.parsers.plaintext import PlaintextParser
@@ -37,6 +38,7 @@ def get_answers(query, traceback, offending_line):
     return answers
 
 
+@filecache(WEEK)
 def get_questions(query):
     """This method ask stackexchange API for questions.
     It then return the answers ids for questions with an accepted answer
@@ -60,10 +62,11 @@ def get_questions(query):
             field = str(question["question_id"])
             question_ids.append(field)
 
-    return question_ids, accepted_answer_ids
+    return tuple(question_ids), tuple(accepted_answer_ids)
 
 
-def get_accepted_answers(accepted_answer_ids: List[str]) -> List[str]:
+@filecache(WEEK)
+def get_accepted_answers(accepted_answer_ids: List[str]) -> Tuple[str]:
     """Take an accepted answer id and return the body of it."""
 
     answers_bodies = []
@@ -72,10 +75,11 @@ def get_accepted_answers(accepted_answer_ids: List[str]) -> List[str]:
         answer_body = response.json()["items"][0]["body"]
         answers_bodies.append(answer_body)
 
-    return answers_bodies
+    return tuple(answers_bodies)
 
 
-def get_most_voted_answers(questions_ids: List[str]) -> List[str]:
+@filecache(WEEK)
+def get_most_voted_answers(questions_ids: List[str]) -> Tuple[str]:
     """Take an accepted answer id and return the body of it.
     As we want only the most voted answer, we can order by vote count
     and limit ansers by one.
@@ -89,7 +93,7 @@ def get_most_voted_answers(questions_ids: List[str]) -> List[str]:
         response = requests.get(url.replace("<id>", str(id_)))
         answer_body = response.json()["items"][0]["body"]
         answers_bodies.append(answer_body)
-    return answers_bodies
+    return tuple(answers_bodies)
 
 
 def parse_summarizer(answer_body):

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ sumy
 html5lib
 pyminifier
 python-slugify
+filecache

--- a/tests/test_answers.py
+++ b/tests/test_answers.py
@@ -62,8 +62,8 @@ def test_get_questions_skip_unanswered_questions():
     with HTTMock(fake_question_request):
         question_ids, accepted_answer_ids = get_questions(query)
 
-    assert question_ids == []
-    assert accepted_answer_ids == ["64332917"]
+    assert question_ids == tuple()
+    assert accepted_answer_ids == tuple(["64332917"])
 
 
 def test_get_accepted_answers_return_only_one_accepted_answer():
@@ -72,4 +72,4 @@ def test_get_accepted_answers_return_only_one_accepted_answer():
     with HTTMock(fake_answer_request):
         answer_bodies = get_accepted_answers(answer_id)
 
-    assert answer_bodies == ["<p>Installing....</p>\n<pre><code>pip3 install package\n</code></pre>\n"]
+    assert answer_bodies == tuple(["<p>Installing....</p>\n<pre><code>pip3 install package\n</code></pre>\n"])


### PR DESCRIPTION
[filecache](https://github.com/ubershmekel/filecache) package is used to cache functions inside the answers module that calls the StackOverflow API. Here are some important details:
- The cache is valid for one week (Most common errors won't have their most voted answers changed in this time so chache could be valid for even longer periods).
- Cache files are stored in the same directory as the module that generates it so these new files were added to .gitignore to avoid them being accidentally committed.
