### PR TITLE
New fields to Answer: author and profile_image

### DIFF
--- a/pycee/answers.py
+++ b/pycee/answers.py
@@ -48,7 +48,7 @@ def get_answers(query, traceback, offending_line, error_message, cache=True, n_a
         answer_body = remove_tags(tester)
         summarized_answers.append(answer_body)
 
-    return summarized_answers
+    return summarized_answers, sorted_answers
 
 
 def ask_stackoverflow(query: str) -> Tuple[Question]:
@@ -75,6 +75,7 @@ def get_answer_content(questions: Tuple[Question]) -> Tuple[Answer]:
 
         response = requests.get(url.replace("<id>", str(question.id)))
         items = response.json()["items"]
+
         if not items:
             continue
 
@@ -86,6 +87,8 @@ def get_answer_content(questions: Tuple[Question]) -> Tuple[Answer]:
                 accepted=items[0]["is_accepted"],
                 score=items[0]["score"],
                 body=items[0]["body"],
+                author=items[0]["owner"]["display_name"],
+                profile_image=items[0]["owner"]["profile_image"],
             )
         )
 
@@ -99,7 +102,14 @@ def get_answer_content(questions: Tuple[Question]) -> Tuple[Answer]:
             # accepted is a filtered list of which the only and first elment is the accepted answer
             accepted = list(filter(lambda a: a["is_accepted"], items))[0]
             answers.append(
-                Answer(id=str(accepted["answer_id"]), accepted=True, score=accepted["score"], body=accepted["body"])
+                Answer(
+                    id=str(accepted["answer_id"]),
+                    accepted=True,
+                    score=accepted["score"],
+                    body=accepted["body"],
+                    author=accepted["owner"]["display_name"],
+                    profile_image=accepted["owner"]["profile_image"],
+                )
             )
 
     return tuple(answers)

--- a/pycee/utils.py
+++ b/pycee/utils.py
@@ -129,7 +129,7 @@ BUILTINS = dir(modules["builtins"])
 
 # namedtuples to represent simple objects
 Question = namedtuple("Question", ["id", "has_accepted"])
-Answer = namedtuple("Answer", ["id", "accepted", "score", "body"])
+Answer = namedtuple("Answer", ["id", "accepted", "score", "body", "author", "profile_image"])
 
 ERROR_MESSAGES = {
     "KeyError": (

--- a/tests/test_answers.py
+++ b/tests/test_answers.py
@@ -32,6 +32,10 @@ answers_data = {
             "answer_id": 4,
             "question_id": 1,
             "body": "Body 4",
+            "owner": {
+                "display_name": "author 4",
+                "profile_image": "foo 4",
+            },
         },
         {
             "is_accepted": True,
@@ -39,6 +43,10 @@ answers_data = {
             "answer_id": 3,
             "question_id": 1,
             "body": "Body 3",
+            "owner": {
+                "display_name": "author 3",
+                "profile_image": "foo 3",
+            },
         },
         {
             "is_accepted": False,
@@ -46,6 +54,10 @@ answers_data = {
             "answer_id": 5,
             "question_id": 1,
             "body": "Body 5",
+            "owner": {
+                "display_name": "author 5",
+                "profile_image": "foo 5",
+            },
         },
     ]
 }
@@ -97,7 +109,11 @@ def test_get_answer_content_from_one_question():
     with HTTMock(answer_response):
         answers = get_answer_content(question_obj)
 
-    assert answers == tuple([Answer("4", False, 20, "Body 4"), Answer("3", True, 10, "Body 3")])
+    expected_answers = [
+        Answer(id="4", accepted=False, score=20, body="Body 4", author="author 4", profile_image="foo 4"),
+        Answer(id="3", accepted=True, score=10, body="Body 3", author="author 3", profile_image="foo 3"),
+    ]
+    assert answers == tuple(expected_answers)
 
 
 def test_get_answer_content_handle_empty_response():

--- a/usage.py
+++ b/usage.py
@@ -16,7 +16,7 @@ def main():
     query, pycee_answer, pydoc_answer = handle_error(
         error_info, offending_line, packages, limit=args.n_questions, dry_run=args.dry_run
     )
-    so_answers = get_answers(
+    so_answers, _ = get_answers(
         query,
         error_info["traceback"],
         offending_line,


### PR DESCRIPTION
These fields were added to serve the PythonBuddy app as complementary information on answers. Here's an example to clarify:

<img src="https://user-images.githubusercontent.com/29216027/101526551-87f20080-396b-11eb-8e3e-3fe22aa78249.png" width="600"/>
