### PR TITLE
Add SyntaxError handlers

### DIFF
--- a/pycee/answers.py
+++ b/pycee/answers.py
@@ -9,6 +9,7 @@ from operator import attrgetter
 from difflib import get_close_matches
 
 import requests
+from html2text import html2text
 from filecache import filecache, WEEK
 from sumy.nlp.tokenizers import Tokenizer
 from sumy.summarizers.luhn import LuhnSummarizer
@@ -19,13 +20,13 @@ from .utils import BUILTINS, ANSWER_URL, QUESTION_ANSWERS_URL
 from .utils import Question, Answer
 
 
-def get_answers(query, traceback, offending_line, error_message, cache=True, n_answers=3):
+def get_so_answers(query, error_info, cache=True, n_answers=3):
     """This coordinate the answer aquisition process. It goes like this:
     1- Use the query to check stackexchange API for related questions
     2- TODO: If stackoverflow API search engine couldn't find questions, ask Google instead
     3- For each question, get the most voted and accepted answers
     4- Sort answers by vote count and limit them
-    3- Summarize the answers and make it ready to output to the user;
+    3- TODO: Summarize long answers and make it ready to output to the user;
     """
 
     questions = None
@@ -42,17 +43,18 @@ def get_answers(query, traceback, offending_line, error_message, cache=True, n_a
     summarized_answers = []
 
     for ans in sorted_answers:
-        # TODO: old logic, should be refactored
-        code_position = identify_code(ans.body)
-        tester = replace_code(ans.body, code_position, traceback, offending_line)
-        answer_body = remove_tags(tester)
-        summarized_answers.append(answer_body)
+        markdown_body = html2text(ans.body)
+        # TODO: summarize long answers
+        summarized_answers.append(markdown_body)
 
     return summarized_answers, sorted_answers
 
 
-def ask_stackoverflow(query: str) -> Tuple[Question]:
+def ask_stackoverflow(query: str) -> Tuple[Question, None]:
     """This method ask StackOverflow (so) API for questions."""
+
+    if query is None:
+        return tuple()
 
     response_json = requests.get(query).json()
     questions = []
@@ -65,7 +67,7 @@ def ask_stackoverflow(query: str) -> Tuple[Question]:
     return tuple(questions)
 
 
-def get_answer_content(questions: Tuple[Question]) -> Tuple[Answer]:
+def get_answer_content(questions: Tuple[Question]) -> Tuple[Answer, None]:
     """Retrieve the most voted and the accepted answers for each question"""
 
     url = QUESTION_ANSWERS_URL + "&order=desc" + "&sort=votes"
@@ -127,48 +129,6 @@ def cached_ask_stackoverflow(*args, **kwargs):
     return ask_stackoverflow(*args, **kwargs)
 
 
-def parse_summarizer(answer_body):
-    """Method to summary an answer body
-    and remove html tags and formating.
-    TODO: has not been refactored yet
-    """
-    summary = None
-    if len(answer_body.split("\n")) <= 4:
-        summary = answer_body
-    else:
-        tmp_summary = get_summary(answer_body)
-        summary = []
-        temp_test = answer_body.replace(". ", "\n")
-        for line in tmp_summary:
-            for sec in temp_test.split("\n"):
-                if (sec.lstrip() != "") and (sec.lstrip() in str(line)):
-                    if "*pre*" in str(line):
-                        sec = sec.replace("*pre*", EMPTY_STRING)
-                        exists = False
-                        for i in summary:
-                            if sec == i:
-                                exists = True
-                        if not exists:
-                            sec = sec.replace("&gt;", ">")
-                            sec = sec.replace("&lt;COMMA_CHAR<")
-                            summary.append(sec)
-                    else:
-                        exists = False
-
-                        for i in summary:
-                            if str(line) == i:
-                                exists = True
-
-                        if not exists:
-                            new_line = str(line)
-                            new_line = new_line.replace("&gt;", ">")
-                            new_line = new_line.replace("&lt;", "<")
-                            summary.append(new_line)
-        summary = "\n".join(summary) + "\n"
-
-    return summary
-
-
 def get_summary(sentences):
     """Convert sentences to single string -> not good for code."""
 
@@ -178,151 +138,3 @@ def get_summary(sentences):
     summariser = LuhnSummarizer()
 
     return summariser(parser.document, length)
-
-
-# Answer parsing
-
-
-def identify_code(text):
-    """Retrieve code from the answer body."""
-
-    start_tag = "<code>"
-    end_tag = "</code>"
-    pos = []  # list to hold code positions
-
-    if start_tag in text:
-        for i, char in enumerate(text):
-            if char == "<":
-                if start_tag == text[i : i + len(start_tag)]:
-                    pos.append([])
-                    pos[len(pos) - 1].append(i + len(start_tag))
-                    if text[i - 5 : i] == "<pre>":
-                        pos[len(pos) - 1].append(1)
-                    else:
-                        pos[len(pos) - 1].append(0)
-                if end_tag == text[i : i + len(end_tag)]:
-                    pos[len(pos) - 1].append(i)
-
-        for i in range(0, len(pos)):
-            tmp = pos[i][2]
-            pos[i][2] = pos[i][1]
-            pos[i][1] = tmp
-    return pos
-
-
-def remove_tags(text):
-    """ docstring later on """
-
-    text = text.replace("<pre>", "*pre*")
-    text = text.replace("</pre>", "*pre*")
-    cleaner = re.compile("<.*?>")
-    clean_text = re.sub(cleaner, "", text)
-    return clean_text
-
-
-def replace_code(text, pos, message, offending_line):
-    """ docstring and refactor work later on """
-
-    new_text = text
-    no_tags = remove_tags(text)
-    no_tags_lines = no_tags.split("\n")
-    error_lines = message.split("\n")
-    error_type = None
-    for line in error_lines:
-        if "Error: " in line:
-            error_type = line.split(SINGLE_SPACE_CHAR, 1)[0]
-
-    error_header = error_lines[1]
-    qa_offending_line = None  # Syntax Error only
-    qa_error_line = None
-
-    # check for compiler text in question/answer
-    regex = r"(File|Traceback)(.+)\n(.+)((\n)|(\n( |\t)+\^))\n(Arithmetic|FloatingPoint|Overflow|ZeroDivision|Assertion|Attribute|Buffer|EOF|Import|ModuleNotFound|Lookup|Index|Key|Memory|Name|UnboundLocal|OS|BlockingIO|ChildProcess|Connection|BrokenPipe|ConnectionAborted|ConnectionRefused|ConnectionReset|FileExists|FileNotFound|Interrupted|IsADirectory|NotADirectory|Permission|ProcessLookup|Timeout|Reference|Runtime|NotImplemented|Recursion|Syntax|Indentation|Tab|System|Type|Value|Unicode|UnicodeDecode|UnicodeEncode|UnicodeTranslate)(Error:)(.+)"
-    match = re.search(regex, no_tags)
-    if match:
-        qa_error_line = match.group(0).split("\n")[1]
-        # ALSO CHECK QUESTION?
-
-    # if SyntaxError we may need to handle differently
-    if error_type == "SyntaxError:" and qa_error_line:
-        if error_header != offending_line:
-            for i in range(len(pos)):
-                previous = None
-                if bool(pos[i][2]) and (match.group(0) not in text[pos[i][0] : pos[i][1]]):
-                    for line in text[pos[i][0] : pos[i][1]].split("\n"):
-                        if line == qa_error_line:
-                            qa_offending_line = previous
-                        previous = line
-
-            # check previous line
-            # if previous line of code, swap and exit
-            if qa_offending_line:
-                qa_offending_line = qa_offending_line.strip()
-            if error_header:
-                error_header = error_header.strip()
-            if qa_error_line:
-                qa_error_line = qa_error_line.strip()
-
-            for i in reversed(pos):
-                j = pos.index(i)
-                if qa_offending_line in text[pos[j][0] : pos[j][1]]:
-                    new_text = new_text[: pos[j][0]] + error_header + new_text[pos[j][1] :]
-                elif qa_error_line in text[pos[j][0] : pos[j][1]]:
-                    new_text = new_text[: pos[j][0]] + offending_line + new_text[pos[j][1] :]
-            return new_text
-
-    if qa_error_line is None:
-        tmpqa_error_line = get_close_matches(offending_line, no_tags_lines, 1, 0.4)
-        if tmpqa_error_line:
-            qa_error_line = tmpqa_error_line[0]
-
-    if (qa_error_line is None) or (qa_error_line == ""):
-        return text
-    # if exists, check for similar lines
-    possible_lines = []
-    if qa_error_line is None:
-        possible_lines = get_close_matches(qa_error_line, no_tags_lines, 3, 0.4)
-    # if exists, substitute variables
-    if len(possible_lines) > 0 or qa_error_line:
-        # tokenise similar to before, may have to group
-        user_variables = []
-        usr_builtins = []
-        tokens = re.split(r"[!@#$%^&*_\-+=\(\)\[\]\{\}\\|~`/?.<>:; ]", error_header)
-        for token in reversed(tokens):
-            if (token not in kwlist) and (token not in BUILTINS):
-                user_variables.append(token)
-            else:
-                usr_builtins.append(token)
-        user_variables = list(reversed(user_variables))
-        usr_builtins = list(reversed(usr_builtins))
-        # split
-        qa_line = None
-        if qa_error_line:
-            qa_line = qa_error_line
-        else:
-            qa_line = possible_lines[0]
-        if "," in qa_line:
-            while (", " in qa_line) or (" ," in qa_line):
-                qa_line = qa_line.replace(", ", COMMA_CHAR)
-                qa_line = qa_line.replace(" ,", COMMA_CHAR)
-        qa_variables = []
-        tokens = re.split(r"[!@#$%^&*_\-+=\(\)\[\]\{\}\\|~`/?.<>:; ]", qa_line)
-        for token in reversed(tokens):
-            if (token not in kwlist) and (token not in BUILTINS):
-                qa_variables.append(token)
-        qa_variables = list(reversed(qa_variables))
-
-        for word in reversed(qa_variables):
-            if word == "":
-                qa_variables.remove(word)
-
-        for word in reversed(user_variables):
-            if not word:
-                user_variables.remove(word)
-
-        newqa_line = qa_line
-        if len(user_variables) == len(qa_variables):
-            for word, i in enumerate(qa_variables):
-                newqa_line.replace(word, user_variables[i])
-
-    return new_text

--- a/pycee/inspection.py
+++ b/pycee/inspection.py
@@ -1,6 +1,7 @@
 """This module will inspect the error source code and the error log."""
 import re
 import sys
+from pprint import pprint
 from dis import get_instructions
 from collections import defaultdict
 from subprocess import Popen, PIPE, STDOUT
@@ -25,6 +26,7 @@ def get_error_info(file_path, stderr=None):
     error_line = get_error_line(traceback)
     file_name = get_file_name(traceback)
     code = get_code(file_path)
+    offending_line = get_offending_line(error_line, code)
 
     error_info = {
         "traceback": traceback,
@@ -33,11 +35,12 @@ def get_error_info(file_path, stderr=None):
         "line": error_line,
         "file": file_name,
         "code": code,
+        "offending_line": offending_line,
     }
 
     if not all(error_info.values()):
         print("Aborting. Some data about the error is missing:")
-        print(error_info)
+        pprint(error_info)
         sys.exit(-1)
 
     return error_info
@@ -161,6 +164,21 @@ def get_code(file_path: str) -> str:
     with open(file_path, "r") as file:
         code = file.read()
     return code
+
+
+def get_offending_line(error_line: int, code: str) -> str:
+    """Extracts the offending line"""
+
+    error_line -= 1
+    code_lines = code.splitlines()
+    offending_line = None
+
+    try:
+        offending_line = code_lines[error_line]
+    except IndexError:
+        offending_line = code_lines[-1]
+
+    return offending_line
 
 
 def get_packages(code: str) -> defaultdict:

--- a/pycee/sym_table.py
+++ b/pycee/sym_table.py
@@ -3,7 +3,6 @@ from typing import List
 import re
 
 from symtable import symtable
-from pyminifier.minification import remove_comments_and_docstrings
 
 
 def trim_and_split_code(code: str, error_line: str) -> List[str]:
@@ -20,26 +19,6 @@ def trim_and_split_code(code: str, error_line: str) -> List[str]:
         trimmed_code = code[0]
 
     return trimmed_code
-
-
-def get_offending_line(error_info):
-    """Gets the offending line."""
-
-    offending_line = None
-    is_syntax_error = error_info["type"] == "SyntaxError"
-    code_lines = error_info["code"].split("\n")
-    error_line = error_info["line"] - 1
-
-    if is_syntax_error:
-        uncommented_code = remove_comments_and_docstrings(error_info["code"])
-        # TODO: remove this?
-        # remove newline char
-        uncommented_code = uncommented_code[: len(uncommented_code) - 1]
-        offending_line = uncommented_code.splitlines()[-error_line]
-    else:
-        offending_line = code_lines[error_line]
-
-    return offending_line
 
 
 def broken_get_sym_table(error_info):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 requests
 sumy
 html5lib
-pyminifier
 python-slugify
 filecache
+html2text
+consolemd

--- a/tests/test_argparser.py
+++ b/tests/test_argparser.py
@@ -30,7 +30,7 @@ def test_store_boolean_args():
         cache=False,  # default is True
         dry_run=True,  # default is False
         rm_cache=True,  # default is False
-        show_pycee_answer=False,  # default is True
+        show_pycee_hint=False,  # default is True
         show_so_answer=False,  # default is True
     )
     parsed_args = parse_args(["foo.py", "-f", "--dry-run", "-rm", "-s", "-p"])
@@ -38,7 +38,7 @@ def test_store_boolean_args():
     assert parsed_args.cache == expected_args.cache
     assert parsed_args.dry_run == expected_args.dry_run
     assert parsed_args.rm_cache == expected_args.rm_cache
-    assert parsed_args.show_pycee_answer == expected_args.show_pycee_answer
+    assert parsed_args.show_pycee_hint == expected_args.show_pycee_hint
     assert parsed_args.show_so_answer == expected_args.show_so_answer
 
 
@@ -50,7 +50,7 @@ def test_default_args():
         cache=True,
         dry_run=False,
         rm_cache=False,
-        show_pycee_answer=True,
+        show_pycee_hint=True,
         show_so_answer=True,
     )
     parsed_args = parse_args(["foo.py"])
@@ -61,5 +61,5 @@ def test_default_args():
     assert parsed_args.cache == expected_args.cache
     assert parsed_args.dry_run == expected_args.dry_run
     assert parsed_args.rm_cache == expected_args.rm_cache
-    assert parsed_args.show_pycee_answer == expected_args.show_pycee_answer
+    assert parsed_args.show_pycee_hint == expected_args.show_pycee_hint
     assert parsed_args.show_so_answer == expected_args.show_so_answer

--- a/tests/test_error_handlers/test_index_error.py
+++ b/tests/test_error_handlers/test_index_error.py
@@ -1,7 +1,7 @@
 import pytest
 
 from pycee.errors import handle_index_error_locally
-from pycee.utils import ERROR_MESSAGES
+from pycee.utils import HINT_MESSAGES
 
 
 @pytest.mark.parametrize(
@@ -13,5 +13,5 @@ from pycee.utils import ERROR_MESSAGES
     ],
 )
 def test_index_error_locally(error_message, error_line, sequence, monkeypatch):
-    monkeypatch.setitem(ERROR_MESSAGES, "IndexError", "<sequence> <line>")
+    monkeypatch.setitem(HINT_MESSAGES, "IndexError", "<sequence> <line>")
     assert handle_index_error_locally(error_message, error_line) == f"{sequence} {error_line}"

--- a/tests/test_error_handlers/test_key_error.py
+++ b/tests/test_error_handlers/test_key_error.py
@@ -1,7 +1,7 @@
 import pytest
 
 from pycee.errors import handle_key_error_locally
-from pycee.utils import ERROR_MESSAGES
+from pycee.utils import HINT_MESSAGES
 
 
 @pytest.mark.parametrize(
@@ -50,7 +50,7 @@ from pycee.utils import ERROR_MESSAGES
     ],
 )
 def test_handle_key_error_with_known_target(error_message, offending_line, expected, monkeypatch):
-    monkeypatch.setitem(ERROR_MESSAGES, "KeyError", "<initial_error>")
+    monkeypatch.setitem(HINT_MESSAGES, "KeyError", "<initial_error>")
     assert handle_key_error_locally(error_message, offending_line) == expected
 
 
@@ -80,5 +80,5 @@ def test_handle_key_error_with_known_target(error_message, offending_line, expec
     ],
 )
 def test_handle_key_error_with_unknown_target(error_message, offending_line, expected, monkeypatch):
-    monkeypatch.setitem(ERROR_MESSAGES, "KeyError", "<initial_error>")
+    monkeypatch.setitem(HINT_MESSAGES, "KeyError", "<initial_error>")
     assert handle_key_error_locally(error_message, offending_line) == expected

--- a/tests/test_error_handlers/test_module_not_found_error.py
+++ b/tests/test_error_handlers/test_module_not_found_error.py
@@ -1,10 +1,10 @@
 import pytest
 
 from pycee.errors import handle_module_error_locally
-from pycee.utils import ERROR_MESSAGES
+from pycee.utils import HINT_MESSAGES
 
 
 def test_module_not_found_error_locally(monkeypatch):
-    monkeypatch.setitem(ERROR_MESSAGES, "ModuleNotFoundError", "<missing_module>")
+    monkeypatch.setitem(HINT_MESSAGES, "ModuleNotFoundError", "<missing_module>")
     error_message = "ModuleNotFoundError: No module named 'sklearn'"
     assert handle_module_error_locally(error_message) == "sklearn"

--- a/tests/test_error_handlers/test_name_error.py
+++ b/tests/test_error_handlers/test_name_error.py
@@ -1,10 +1,10 @@
 import pytest
 
 from pycee.errors import handle_name_error_locally
-from pycee.utils import ERROR_MESSAGES
+from pycee.utils import HINT_MESSAGES
 
 
 def test_module_not_found_error_locally(monkeypatch):
-    monkeypatch.setitem(ERROR_MESSAGES, "NameError", "<missing_name>")
+    monkeypatch.setitem(HINT_MESSAGES, "NameError", "<missing_name>")
     error_message = "NameError: name 'some_variable' is not defined"
     assert handle_name_error_locally(error_message) == "some_variable"

--- a/tests/test_error_handlers/test_syntax_error.py
+++ b/tests/test_error_handlers/test_syntax_error.py
@@ -1,0 +1,21 @@
+import pytest
+from pycee import errors
+from pycee import utils
+
+
+def test_syntax_error_locally_with_generic_error(monkeypatch):
+    monkeypatch.setitem(utils.HINT_MESSAGES, "SyntaxError", "<line>")
+    assert errors.handle_syntax_error_locally(error_message="SyntaxError: invalid syntax", error_line=123) == "123"
+    assert errors.handle_syntax_error_locally("SyntaxError: unexpected EOF while parsing", error_line=123) == None
+
+
+def test_syntax_error_locally_with_known_error(monkeypatch):
+    def mock_url(error):
+        return "base_url:" + error
+
+    monkeypatch.setattr(errors, "url_for_error", mock_url)
+    assert (
+        errors.handle_syntax_error(error_message="SyntaxError: unexpected EOF while parsing")
+        == "base_url:syntaxerror+unexpected+eof+while+parsing"
+    )
+    assert errors.handle_syntax_error(error_message="SyntaxError: invalid syntax") == None

--- a/tests/test_inspection.py
+++ b/tests/test_inspection.py
@@ -10,6 +10,7 @@ from pycee.inspection import (
     get_file_name,
     get_code,
     get_packages,
+    get_offending_line,
 )
 
 
@@ -85,9 +86,46 @@ def test_get_file_name(source_file_fixture, traceback_fixture):
     assert file_name == str(source_file_fixture)
 
 
-def test_get_code(source_file_fixture, traceback_fixture):
+def test_get_code(source_file_fixture):
 
     assert get_code(str(source_file_fixture)) == source_file_fixture.read()
+
+
+def test_get_offending_line_module_error(traceback_fixture, source_file_fixture):
+
+    error_line = get_error_line(traceback_fixture)
+    print(error_line)
+    code = get_code(str(source_file_fixture))
+    offending_line = get_offending_line(error_line, code)
+    assert offending_line == "import not_a_module"
+
+
+def test_get_offending_line_attr_error():
+    error_line = 8
+    code = "import os\nimport math\n\n\nprint(os.getcwd())\nprint(math.pi)\nmath.dir\n"
+    offending_line = get_offending_line(error_line, code)
+    assert offending_line == "math.dir"
+
+
+def test_get_offending_line_type_error():
+    error_line = 9
+    code = "import os\nimport math\n\n\nprint(os.getcwd())\nprint(math.pi)\n\n# will raise an typeerror\nmath.pi + 'not an int'\n\n\n\n# just for testing purposes\n\n\n"
+    offending_line = get_offending_line(error_line, code)
+    assert offending_line == "math.pi + 'not an int'"
+
+
+def test_get_offending_line_syntax_error_EOL_literal():
+    error_line = 10
+    code = "import os\nimport math\n\n\nprint(os.getcwd())\nprint(math.pi)\n\n# will raise an syntax error\n\nprint('error)\n\n\n# just for testing purposes\n\n\n"
+    offending_line = get_offending_line(error_line, code)
+    assert offending_line == "print('error)"
+
+
+def test_get_offending_line_syntax_error_generic():
+    error_line = 8
+    code = "import os\nimport math\n\n\nprint(os.getcwd())\nprint(math.pi)\n\ndef foo(bar)\n    pass\n\n# just for testing purposes\n\n\n"
+    offending_line = get_offending_line(error_line, code)
+    assert offending_line == "def foo(bar)"
 
 
 def test_get_packages():

--- a/usage.py
+++ b/usage.py
@@ -1,30 +1,25 @@
-from pycee.answers import get_answers
+from pycee.answers import get_so_answers
 from pycee.errors import handle_error
 from pycee.inspection import get_error_info, get_packages
-from pycee.sym_table import get_offending_line
 from pycee.utils import parse_args, remove_cache, print_answers
 
 
 def main():
 
     args = parse_args()
+
     if args.rm_cache:
         remove_cache()
+
     error_info = get_error_info(args.file_name)
-    offending_line = get_offending_line(error_info)
-    packages = get_packages(error_info["code"])
-    query, pycee_answer, pydoc_answer = handle_error(
-        error_info, offending_line, packages, limit=args.n_questions, dry_run=args.dry_run
-    )
-    so_answers, _ = get_answers(
+    query, pycee_hint, pydoc_answer = handle_error(error_info, n_questions=args.n_questions, dry_run=args.dry_run)
+    so_answers, _ = get_so_answers(
         query,
-        error_info["traceback"],
-        offending_line,
-        error_info["message"],
+        error_info,
         cache=args.cache,
         n_answers=args.n_answers,
     )
-    print_answers(so_answers, pycee_answer, pydoc_answer, args)
+    print_answers(so_answers, pycee_hint, pydoc_answer, args)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
I got excited and started changing several highly coupled portions of code and the result is quite large and hard to read pull, my bad 🙇‍♂️. 
Here's the changelog:
- Add SyntaxError handlers including tests
- Add [html2text](https://github.com/Alir3z4/html2text) to process an answer body in favor of the old confusing logic
- Add [consolemd](https://github.com/kneufeld/consolemd) to render these markdown body answers to the command line
- Abstract get_offending_line out of usage example and into inspection module (main methods now have simpler signatures)

In what concerns the new error handler of SyntaxError, here's what I chose to implement:
The strategy is that if the user has a generic syntax error, give him/her a pycee hint on fixing simples syntax errors.
Otherwise, if the user is facing a specific syntax error (which can be checked using the traceback error message) then let's search StackOverflow for an appropriate answer.

Handling multiple tricky cases of syntax errors is such a burden and would make the code larger and cyclomatic complex so the best approach in terms of effort vs code complexity is to help the user with simple tips that will probably solve the simpler syntax error cases. And lastly, considering that PythonBuddy integration, our focus, for now, has a linter included, a simpler syntax error will be well covered by pylint.

 