### PR TITLE
Bugfix: default for Stackoverflow users with no profile image

### DIFF
--- a/pycee/answers.py
+++ b/pycee/answers.py
@@ -90,7 +90,7 @@ def get_answer_content(questions: Tuple[Question]) -> Tuple[Answer, None]:
                 score=items[0]["score"],
                 body=items[0]["body"],
                 author=items[0]["owner"]["display_name"],
-                profile_image=items[0]["owner"]["profile_image"],
+                profile_image=items[0]["owner"].get("profile_image", None),
             )
         )
 
@@ -110,7 +110,7 @@ def get_answer_content(questions: Tuple[Question]) -> Tuple[Answer, None]:
                     score=accepted["score"],
                     body=accepted["body"],
                     author=accepted["owner"]["display_name"],
-                    profile_image=accepted["owner"]["profile_image"],
+                    profile_image=accepted["owner"].get("profile_image", None),
                 )
             )
 

--- a/tests/test_answers.py
+++ b/tests/test_answers.py
@@ -45,7 +45,6 @@ answers_data = {
             "body": "Body 3",
             "owner": {
                 "display_name": "author 3",
-                "profile_image": "foo 3",
             },
         },
         {
@@ -111,7 +110,7 @@ def test_get_answer_content_from_one_question():
 
     expected_answers = [
         Answer(id="4", accepted=False, score=20, body="Body 4", author="author 4", profile_image="foo 4"),
-        Answer(id="3", accepted=True, score=10, body="Body 3", author="author 3", profile_image="foo 3"),
+        Answer(id="3", accepted=True, score=10, body="Body 3", author="author 3", profile_image=None),
     ]
     assert answers == tuple(expected_answers)
 


### PR DESCRIPTION
If a Stackoverflow user has no profile image, None is provided as default. Otherwise this edge case would raise an AttributeError