### PR TITLE
Implement logic to retrieve questions from Google search engine

### DIFF
--- a/pycee/errors.py
+++ b/pycee/errors.py
@@ -8,10 +8,11 @@ from typing import List, Union
 from collections import defaultdict
 from importlib import import_module
 from difflib import get_close_matches
+from argparse import Namespace
 
 from slugify import slugify
 
-from .utils import DATA_TYPES, BUILTINS, HINT_MESSAGES, API_SEARCH_URL
+from .utils import DATA_TYPES, BUILTINS, HINT_MESSAGES, SEARCH_URL
 from .utils import (
     SINGLE_QUOTE_CHAR,
     DOUBLE_QUOTE_CHAR,
@@ -20,7 +21,7 @@ from .utils import (
 )
 
 
-def handle_error(error_info: dict, n_questions: int, dry_run: bool = False) -> str:
+def handle_error(error_info: dict, cmd_args: Namespace) -> str:
     """Process the incoming error as needed and outputs three possible answer.
     output:
     query: an URL containing an stackoverflow query about the error.
@@ -66,9 +67,9 @@ def handle_error(error_info: dict, n_questions: int, dry_run: bool = False) -> s
     else:
         query = url_for_error(error_message)  # default query
 
-    query = set_pagesize(query, n_questions) if query else None
+    query = set_pagesize(query, cmd_args.n_questions) if query else None
 
-    if dry_run:
+    if cmd_args.dry_run:
         print(query)
         exit()
 
@@ -270,7 +271,7 @@ def get_query_params(error_message: str):
 def url_for_error(error_message: str) -> str:
     """Build a valid search url."""
 
-    return API_SEARCH_URL + get_query_params(error_message)
+    return SEARCH_URL + get_query_params(error_message)
 
 
 def get_quoted_words(error_message: str) -> List[str]:

--- a/pycee/utils.py
+++ b/pycee/utils.py
@@ -26,7 +26,7 @@ def parse_args(args=sys.argv[1:]):
         choices=range(1, 6),
         default=3,
         dest="n_questions",
-        help="The number of questions to retrieve from Stackoverflow",
+        help="Number of questions to retrieve from Stackoverflow",
     )
     parser.add_argument(
         "-a",
@@ -35,7 +35,15 @@ def parse_args(args=sys.argv[1:]):
         choices=range(1, 5),
         default=3,
         dest="n_answers",
-        help="The number of answers to display",
+        help="Number of answers to display",
+    )
+    parser.add_argument(
+        "-g",
+        "--from-google-search",
+        dest="google_search_only",
+        action="store_true",
+        default=False,
+        help="Retrieve questions only from Google search engine",
     )
     parser.add_argument(
         "-s",
@@ -43,7 +51,7 @@ def parse_args(args=sys.argv[1:]):
         dest="show_pycee_hint",
         action="store_false",
         default=True,
-        help="Get answers only from Stackoverflow",
+        help="Output only StackOverflow answers for the error",
     )
     parser.add_argument(
         "-p",
@@ -51,7 +59,7 @@ def parse_args(args=sys.argv[1:]):
         dest="show_so_answer",
         action="store_false",
         default=True,
-        help="Get answers only from from pycee",
+        help="Output only pycee hint for the error",
     )
     parser.add_argument(
         "-d",
@@ -127,9 +135,8 @@ EMPTY_STRING = ""
 COMMA_CHAR = ","
 
 BASE_URL = "https://api.stackexchange.com/2.2"
-API_SEARCH_URL = BASE_URL + "/search?site=stackoverflow"
-ANSWER_URL = BASE_URL + "/answers/<id>?site=stackoverflow&filter=withbody"
-QUESTION_ANSWERS_URL = BASE_URL + "/questions/<id>/answers?site=stackoverflow&filter=withbody"
+SEARCH_URL = BASE_URL + "/search?site=stackoverflow"
+ANSWERS_URL = BASE_URL + "/questions/<id>/answers?site=stackoverflow&filter=withbody"
 
 # A list of all standard exeptions
 BUILTINS = dir(sys.modules["builtins"])

--- a/pycee/utils.py
+++ b/pycee/utils.py
@@ -127,7 +127,6 @@ def print_answers(so_answers, pycee_hint, pydoc_answer, args):
 
 
 # These are some constants we use throughout the codebase
-DEFAULT_HTML_PARSER = "html5lib"
 SINGLE_QUOTE_CHAR = "'"
 DOUBLE_QUOTE_CHAR = '"'
 SINGLE_SPACE_CHAR = " "

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
 requests
-sumy
-html5lib
 python-slugify
 filecache
+googlesearch-python
 html2text
 consolemd

--- a/tests/test_answers.py
+++ b/tests/test_answers.py
@@ -1,6 +1,8 @@
 from httmock import all_requests, HTTMock
-from pycee.answers import ask_stackoverflow, get_answer_content
-from pycee.utils import ANSWER_URL, Question, Answer
+import googlesearch
+
+from pycee.answers import _ask_stackoverflow, _ask_google, _get_answer_content
+from pycee.utils import Question, Answer
 
 
 # data resources
@@ -14,13 +16,13 @@ questions_data = {
             "is_answered": True,
             "accepted_answer_id": 4,
             "answer_count": 1,
-            "question_id": 1,
+            "question_id": "1",
         },
         {
             "is_answered": False,
             "answer_count": 0,
             "score": 0,
-            "question_id": 2,
+            "question_id": "2",
         },
     ]
 }
@@ -30,7 +32,7 @@ answers_data = {
             "is_accepted": False,
             "score": 20,
             "answer_id": 4,
-            "question_id": 1,
+            "question_id": "1",
             "body": "Body 4",
             "owner": {
                 "display_name": "author 4",
@@ -41,7 +43,7 @@ answers_data = {
             "is_accepted": True,
             "score": 10,
             "answer_id": 3,
-            "question_id": 1,
+            "question_id": "1",
             "body": "Body 3",
             "owner": {
                 "display_name": "author 3",
@@ -51,7 +53,7 @@ answers_data = {
             "is_accepted": False,
             "score": 5,
             "answer_id": 5,
-            "question_id": 1,
+            "question_id": "1",
             "body": "Body 5",
             "owner": {
                 "display_name": "author 5",
@@ -61,21 +63,19 @@ answers_data = {
     ]
 }
 
-# mocks
-
 
 @all_requests
-def question_response(url, request):
+def so_question_response(url, request):
     return {"status_code": 200, "content": questions_data}
 
 
 @all_requests
-def empty_question_response(url, request):
+def empty_so_question_response(url, request):
     return {"status_code": 200, "content": empty_questions}
 
 
 @all_requests
-def answer_response(url, request):
+def answers_response(url, request):
     return {"status_code": 200, "content": answers_data}
 
 
@@ -90,23 +90,44 @@ def empty_answers_response(url, request):
 def test_ask_stackoverflow_skip_unanswered_questions():
 
     question_obj = tuple([Question(id="1", has_accepted=True)])
-    with HTTMock(question_response):
-        questions = ask_stackoverflow(fake_query)
+    with HTTMock(so_question_response):
+        questions = _ask_stackoverflow(fake_query)
     assert questions == question_obj
 
 
 def test_ask_stackoverflow_can_handle_empty_response():
 
-    with HTTMock(empty_question_response):
-        questions = ask_stackoverflow(fake_query)
+    with HTTMock(empty_so_question_response):
+        questions = _ask_stackoverflow(fake_query)
     assert questions == tuple([])
+
+
+def test_ask_google_parses_urls_correctly(monkeypatch):
+
+    questions_from_google = [
+        "https://stackoverflow.com/questions/666666/not-a-real-question",
+        "https://stackoverflow.com/questions/999999/foo-bar-baz",
+    ]
+    expected = tuple(
+        [
+            Question(id="666666", has_accepted=None),
+            Question(id="999999", has_accepted=None),
+        ]
+    )
+
+    def mock_google_search(n_questions):
+        return questions_from_google
+
+    monkeypatch.setattr(googlesearch, "search", mock_google_search)
+    questions = _ask_google("TestExpection: Not a real error :)", n_questions=3)
+    assert questions == expected
 
 
 def test_get_answer_content_from_one_question():
 
-    question_obj = tuple([Question(id=1, has_accepted=True)])
-    with HTTMock(answer_response):
-        answers = get_answer_content(question_obj)
+    question_obj = tuple([Question(id="1", has_accepted=True)])
+    with HTTMock(answers_response):
+        answers = _get_answer_content(question_obj)
 
     expected_answers = [
         Answer(id="4", accepted=False, score=20, body="Body 4", author="author 4", profile_image="foo 4"),
@@ -117,7 +138,7 @@ def test_get_answer_content_from_one_question():
 
 def test_get_answer_content_handle_empty_response():
 
-    question_obj = tuple([Question(id=1, has_accepted=True)])
+    question_obj = tuple([Question(id="1", has_accepted=True)])
     with HTTMock(empty_answers_response):
-        questions = get_answer_content(question_obj)
+        questions = _get_answer_content(question_obj)
     assert questions == tuple([])

--- a/tests/test_argparser.py
+++ b/tests/test_argparser.py
@@ -30,14 +30,16 @@ def test_store_boolean_args():
         cache=False,  # default is True
         dry_run=True,  # default is False
         rm_cache=True,  # default is False
+        google_search_only=True,  # default is False
         show_pycee_hint=False,  # default is True
         show_so_answer=False,  # default is True
     )
-    parsed_args = parse_args(["foo.py", "-f", "--dry-run", "-rm", "-s", "-p"])
+    parsed_args = parse_args(["foo.py", "-f", "--dry-run", "-rm", "-g", "-s", "-p"])
 
     assert parsed_args.cache == expected_args.cache
     assert parsed_args.dry_run == expected_args.dry_run
     assert parsed_args.rm_cache == expected_args.rm_cache
+    assert parsed_args.google_search_only == expected_args.google_search_only
     assert parsed_args.show_pycee_hint == expected_args.show_pycee_hint
     assert parsed_args.show_so_answer == expected_args.show_so_answer
 
@@ -50,6 +52,7 @@ def test_default_args():
         cache=True,
         dry_run=False,
         rm_cache=False,
+        google_search_only=False,
         show_pycee_hint=True,
         show_so_answer=True,
     )
@@ -61,5 +64,6 @@ def test_default_args():
     assert parsed_args.cache == expected_args.cache
     assert parsed_args.dry_run == expected_args.dry_run
     assert parsed_args.rm_cache == expected_args.rm_cache
+    assert parsed_args.google_search_only == expected_args.google_search_only
     assert parsed_args.show_pycee_hint == expected_args.show_pycee_hint
     assert parsed_args.show_so_answer == expected_args.show_so_answer

--- a/usage.py
+++ b/usage.py
@@ -1,4 +1,4 @@
-from pycee.answers import get_so_answers
+from pycee.answers import get_answers
 from pycee.errors import handle_error
 from pycee.inspection import get_error_info, get_packages
 from pycee.utils import parse_args, remove_cache, print_answers
@@ -12,13 +12,8 @@ def main():
         remove_cache()
 
     error_info = get_error_info(args.file_name)
-    query, pycee_hint, pydoc_answer = handle_error(error_info, n_questions=args.n_questions, dry_run=args.dry_run)
-    so_answers, _ = get_so_answers(
-        query,
-        error_info,
-        cache=args.cache,
-        n_answers=args.n_answers,
-    )
+    query, pycee_hint, pydoc_answer = handle_error(error_info, args)
+    so_answers, _ = get_answers(query, error_info, args)
     print_answers(so_answers, pycee_hint, pydoc_answer, args)
 
 


### PR DESCRIPTION
This is very useful as sometimes StackOverflow search engine, a very limited one, that only considers the title of questions in searches, may not find any related questions whereas Google search engine will almost always find something useful.

Current logic will let questions from StackOverflow have priority as if part of the error message is contained in the question title, it's almost certain that the question is relevant to the error. As a plan B, if StackOverflow did not find questions for the error, the Google search engine will. A cmd argument was added to let users choose to get questions only from Google as an alternative. Tests for both new features are included.

Small changes:
- parsed args are now passed directly to methods that require them, in order to make their signatures simpler
- cache will last for a month (instead of a week), which a little more efficient considering that even in a month answers may not change at all.