### PR TITLE
setup coverage report

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -21,7 +21,25 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install pytest
+        pip install pytest-cov
         if [ -f requirements.txt ]; then pip install -r requirements-dev.txt; fi
     - name: Test with pytest
       run: |
         pytest
+    - name: Generate coverage report
+      run: |
+        pytest --cov=./ --cov-report=xml
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v1.0.5
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        file: ./coverage.xml
+        files: ./coverage1.xml,./coverage2.xml
+        directory: ./coverage/reports/
+        flags: unittests
+        env_vars: OS,PYTHON
+        name: codecov-umbrella
+        fail_ci_if_error: true
+        path_to_write_report: ./coverage/codecov_report.txt
+        verbose: true
+    - run: bash <(curl -s https://codecov.io/bash)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Pycee
 
-Pycee is a tool to provide possible solutions for errors in python code. 
+[![codecov](https://codecov.io/gh/marceloFA/pycee2/branch/master/graph/badge.svg?token=MQI078A12M)](https://codecov.io/gh/marceloFA/pycee2)
+
+Pycee is a tool to provide possible solutions for errors in python code.
 Solutions are from Stackoverflow questions that may be related to the code error.
 This is a reimplementation of [Emillie Thiselton's Pycee](https://github.com/EmillieT/Pycee).
 
@@ -19,10 +21,10 @@ pip3 install pycee2
 After installation, all you have to do is to call ``pycee`` passing the name of the file that contains the error.
 
 ```console
- pycee file_with_error.py 
+ pycee file_with_error.py
  ```
 
-Here's an example: 
+Here's an example:
 Suppose ``script.py`` contains the following code:
 ```python
 # Brazil world cup titles by year
@@ -51,7 +53,7 @@ E.g, if your list was [1, 3, 5, 7], and you asked for the element at index
 10, you would be well out of bounds and receive an error, as only elements 0
 through 3 exist.
 
-... 
+...
 (rest of the output with two more answers omitted from this example)
 ```
 
@@ -76,7 +78,7 @@ source venv/bin/activate
 pip3 install -r requirements.txt requirements-dev.txt
 
 #  using pycee in development mode, from the project root
-python3 usage.py example_code.py 
+python3 usage.py example_code.py
 
 # running tests, from the project root
 pytest


### PR DESCRIPTION
we need to install pytest-cov to generate coverage information, Github actions can do this for us running pip install pytest-cov, When this happens, pytest-cov generates some files and folders (.coverage, coverage.xml). To interpret the data in these files we will use codecov, which will read them and show us some coverage information. The most important thing here is the percentage of coverage, we don't need much more data about it.
a badge will be available in the readme.