### PR TITLE
Add new error handler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ output.txt
 pycee/*cache.bak
 pycee/*cache.dat
 pycee/*cache.dir
+*.py.cache

--- a/pycee/errors.py
+++ b/pycee/errors.py
@@ -26,10 +26,11 @@ def handle_error(error_info: dict, cmd_args: Namespace) -> str:
     pycee_hint = None
     error_type = error_info["type"]
     error_message = error_info["message"]
+    error_line = error_info["line"]
 
     if error_type == "SyntaxError":
-        pycee_hint = handle_syntax_error_locally(error_info["message"], error_info["line"])
-        query = handle_syntax_error(error_info["message"])
+        pycee_hint = handle_syntax_error_locally(error_message, error_line)
+        query = handle_syntax_error(error_message)
 
     elif error_type == "TabError":
         query = handle_tab_error(error_message)
@@ -38,7 +39,7 @@ def handle_error(error_info: dict, cmd_args: Namespace) -> str:
         query = handle_indentation_error(error_message)
 
     elif error_type == "IndexError":
-        pycee_hint = handle_index_error_locally(error_message, error_info["line"])
+        pycee_hint = handle_index_error_locally(error_message, error_line)
         query = handle_index_error(error_message)
 
     elif error_type == "ModuleNotFoundError":
@@ -60,7 +61,7 @@ def handle_error(error_info: dict, cmd_args: Namespace) -> str:
         query = handle_name_error(error_message)
 
     elif error_type == "ZeroDivisionError":
-        pycee_hint = handle_zero_division_error_locally(error_message)
+        pycee_hint = handle_zero_division_error_locally(error_line)
         query = handle_zero_division_error(error_message)
 
     else:
@@ -258,9 +259,9 @@ def handle_zero_division_error(error_message):
     return url_for_error(message)
 
 
-def handle_zero_division_error_locally(error_message, error_line):
+def handle_zero_division_error_locally(error_line):
     """Process an ZeroDivisionError"""
-    hint = HINT_MESSAGES["ZeroDivisionError"]
+    hint = HINT_MESSAGES["ZeroDivisionError"].replace("<line>", str(error_line))
     return hint
 
 

--- a/pycee/errors.py
+++ b/pycee/errors.py
@@ -59,6 +59,10 @@ def handle_error(error_info: dict, cmd_args: Namespace) -> str:
         pycee_hint = handle_name_error_locally(error_message)
         query = handle_name_error(error_message)
 
+    elif error_type == "ZeroDivisionError":
+        pycee_hint = handle_zero_division_error_locally(error_message)
+        query = handle_zero_division_error(error_message)
+
     else:
         query = url_for_error(error_message)  # default query
 
@@ -245,6 +249,19 @@ def handle_type_error(error_message):
     message = slugify(message, separator="+")
 
     return url_for_error(message)
+
+
+def handle_zero_division_error(error_message):
+    """Process an ZeroDivisionError"""
+
+    message = remove_exception_from_error_message(error_message)
+    return url_for_error(message)
+
+
+def handle_zero_division_error_locally(error_message, error_line):
+    """Process an ZeroDivisionError"""
+    hint = HINT_MESSAGES["ZeroDivisionError"]
+    return hint
 
 
 # Helper methods below

--- a/pycee/utils.py
+++ b/pycee/utils.py
@@ -10,7 +10,7 @@ from consolemd import Renderer
 
 
 def parse_args(args=sys.argv[1:]):
-    """A simple argparser to be used when pycee is executed as a script."""
+    """A simple argparse to be used when pycee is executed as a script."""
 
     parser = argparse.ArgumentParser("pycee2", description="Pycee is a tool to provide user friendly error messages.")
     parser.add_argument(
@@ -96,12 +96,12 @@ def remove_cache():
     local_cache = glob.glob("pycee/*.cache*")
     files = package_cache + local_cache
     print("Cache removed!\nPlease run pycee again without -rm or --remove-cache argument to get your answers")
-    # excecvp replace the curent process
+    # excecvp replace the current process
     # This is currently necessary because filecache package
     # wouldn't let me delete all cache files on the main process
     # -f so not found files won't polute the terminal
     os.execvp("rm", ["rm", "-f"] + files)
-    # after execv vp finishes executing rm it exites
+    # after execv vp finishes executing rm it exits
 
 
 def print_answers(so_answers, pycee_hint, pydoc_answer, args):
@@ -161,13 +161,13 @@ HINT_MESSAGES = {
         "\nif this module can be installed using pip like: 'pip install <missing_module>'"
     ),
     "IndexError": (
-        "You tried to acess an index that does not exist in a <sequence> at line <line>."
+        "You tried to access an index that does not exist in a <sequence> at line <line>."
         "\nAn IndexError happens when asking for non existing indexes values of sequences."
         "\nSequences can be lists, tuples and range objects."
         "\nTo fix this make sure that the index value is valid."
     ),
     "SyntaxError": (
-        "You have a syntax error somewehre arround line <line>"
+        "You have a syntax error somewhere around line <line>"
         "\nGenerally, syntax errors occurs when multiple code statements are interpreted as if they were one."
         "\nThis may be caused by several simple issues, below is a list of them."
         "\nYou should check if your code contains any of these issues."
@@ -182,9 +182,9 @@ HINT_MESSAGES = {
         "\nSource: https://www.openbookproject.net/thinkcs/python/english2e/app_a.html"
     ),
     "ZeroDivisionError": (
-        "You have tried to divide a number by zero"
-        "\nCheck the division operations to find the error."
-        "\nDivision operations where the divisor is generate by a range() can throw this error if the range() starts at 0"
+        "You have tried to divide a number by zero around line <line>"
+        "\nCheck the division operation to find the error."
+        "\nDivision operations where the divisor is generate by a range() can throw this error if the range() starts at 0."
     ),
 }
 

--- a/pycee/utils.py
+++ b/pycee/utils.py
@@ -181,6 +181,11 @@ HINT_MESSAGES = {
         "\n5- Check for the classic '=' instead of '==' in a conditional statement."
         "\nSource: https://www.openbookproject.net/thinkcs/python/english2e/app_a.html"
     ),
+    "ZeroDivisionError": (
+        "You have tried to divide a number by zero"
+        "\nCheck the division operations to find the error."
+        "\nDivision operations where the divisor is generate by a range() can throw this error if the range() starts at 0"
+    ),
 }
 
 # standard python3 datatypes

--- a/tests/test_error_handlers/test_zero_division_error.py
+++ b/tests/test_error_handlers/test_zero_division_error.py
@@ -1,0 +1,8 @@
+from pycee import errors
+
+
+def test_handle_zero_division_error():
+    assert (
+        errors.handle_zero_division_error("ZeroDivisionError: division by zero")
+        == "https://api.stackexchange.com/2.2/search?site=stackoverflow&order=desc&sort=relevance&tagged=python&intitle=division+by+zero"
+    )

--- a/tests/test_error_handlers/test_zero_division_error.py
+++ b/tests/test_error_handlers/test_zero_division_error.py
@@ -1,4 +1,6 @@
+import pytest
 from pycee import errors
+from pycee.utils import HINT_MESSAGES
 
 
 def test_handle_zero_division_error():
@@ -6,3 +8,8 @@ def test_handle_zero_division_error():
         errors.handle_zero_division_error("ZeroDivisionError: division by zero")
         == "https://api.stackexchange.com/2.2/search?site=stackoverflow&order=desc&sort=relevance&tagged=python&intitle=division+by+zero"
     )
+
+
+def test_handle_zero_division_error_locally(monkeypatch):
+    monkeypatch.setitem(HINT_MESSAGES, "ZeroDivisionError", "<line>")
+    assert errors.handle_zero_division_error_locally(error_line=5) == "5"


### PR DESCRIPTION
This PR adds a new error handler to ZeroDivisionError. Since we can do it easily, we'll handle it locally too. I've added tests for this implementation aiming to help to conclude #20. Some small refactors are included, like define `error_line` at `errors.py` because we probably will use it several times. Codes that were using `error_info["line"]` have been refactored.